### PR TITLE
Reinstall RPMs before post-restore-config with no events

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -45,9 +45,11 @@ $event = "nethserver-backup-config-save";
 
 $event = "post-restore-config";
 
-event_actions($event, 
-    'nethserver-backup-config-apply' => '70',
-);
+event_actions($event, qw(
+    adjust-fixnetwork-flag 01
+    interface-update-cond 70
+    system-adjust 70
+));
 
 
 #--------------------------------------------------

--- a/root/etc/e-smith/events/actions/interface-update-cond
+++ b/root/etc/e-smith/events/actions/interface-update-cond
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2017 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+flag=/var/run/.nethserver-fixnetwork
+
+if [[ ! -f $flag ]]; then
+    # remove the event name from the arg list:
+    shift
+    exec /sbin/e-smith/signal-event interface-update $*
+fi
+

--- a/root/etc/e-smith/events/actions/nethserver-backup-config-apply
+++ b/root/etc/e-smith/events/actions/nethserver-backup-config-apply
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-#
-# This event will reconfigure the entire system because
-# it invokes system-adjust the end:
-#
-/sbin/e-smith/signal-event hostname-modify

--- a/root/etc/e-smith/events/actions/restore-config-reinstall
+++ b/root/etc/e-smith/events/actions/restore-config-reinstall
@@ -22,5 +22,5 @@
 
 if [ -f /var/lib/nethserver/backup/package-list ]; then
     packages=$(sed ':a;N;$!ba;s/\n/ /g' /var/lib/nethserver/backup/package-list);
-    yum install -y $packages
+    yum --disableplugin=nethserver_events install -y $packages
 fi


### PR DESCRIPTION
- Disable *-update events during package reinstall.
- Run *-update events once, after the full configuration state has been restored. 
- Detect network interface state changes: can we run interface-update safely?

NethServer/dev#5188
