### PR TITLE
Do not run cronjob if data backup is active

### DIFF
--- a/root/etc/cron.d/backup-config
+++ b/root/etc/cron.d/backup-config
@@ -1,3 +1,0 @@
-# Execute configuration backup if enabled
-15 0 * * *   root /usr/libexec/nethserver/backup-config-cron
-

--- a/root/etc/cron.daily/backup-config-cron
+++ b/root/etc/cron.daily/backup-config-cron
@@ -20,10 +20,11 @@
 # along with NethServer.  If not, see COPYING.
 #
 
+# Knowing the execution context could be useful to pre/post backup-config 
+# event actions:
 export BACKUP_CONFIG_CRONJOB=1
 
 BackupDataStatus=$(/sbin/e-smith/config getprop backup-data status)
-
 if [[ "${BackupDataStatus}" == "enabled" ]]; then
     exit 0;
 fi

--- a/root/usr/libexec/nethserver/backup-config-cron
+++ b/root/usr/libexec/nethserver/backup-config-cron
@@ -20,6 +20,14 @@
 # along with NethServer.  If not, see COPYING.
 #
 
+export BACKUP_CONFIG_CRONJOB=1
+
+BackupDataStatus=$(/sbin/e-smith/config getprop backup-data status)
+
+if [[ "${BackupDataStatus}" == "enabled" ]]; then
+    exit 0;
+fi
+
 # Run the backup configuration
 /sbin/e-smith/backup-config
 


### PR DESCRIPTION
The ``backup-data`` command runs also ``backup-config``. It is scheduled by the system admin to run at a specific time of the day. We can obey admin's rule instead of running backup-config at a fixed time (00:15).

NethServer/dev#5314