### PR TITLE
Do not try to reinstall existing dependencies

### DIFF
--- a/root/etc/nethserver/todos.d/50restore-modules
+++ b/root/etc/nethserver/todos.d/50restore-modules
@@ -38,7 +38,7 @@ try:
         for line in fp:
             packages.append(line.rstrip())
 
-    args = ['/usr/bin/rpm', '-q']
+    args = ['/usr/bin/rpm', '-q', '--whatprovides']
     args.extend(packages)
     exit_code = subprocess.check_call(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 except subprocess.CalledProcessError as e:


### PR DESCRIPTION
If a package obsoletes another, an old backup still requires it. This
fix search for symbols instead of package names: if a recent package
provides the old one it is not considered as missing.