### PR TITLE
NS 6 upgrade: always fix fstab

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -47,6 +47,7 @@ event_actions($event, qw(
     nethserver-backup-config-setupgradeflag 00
     adjust-fixnetwork-flag 01
     interface-update-cond 70
+    nethserver-backup-config-fixfstab 70
     system-adjust 70
     nethserver-backup-config-clearupgradeflag-cond 99
 ));

--- a/root/etc/e-smith/events/actions/nethserver-backup-config-fixfstab
+++ b/root/etc/e-smith/events/actions/nethserver-backup-config-fixfstab
@@ -1,0 +1,73 @@
+#!/usr/bin/perl
+
+#
+# Issue https://github.com/NethServer/dev/issues/5388
+#
+# Copyright (C) 2017 Nethesis S.r.l.
+# 
+# This script is part of NethServer.
+# 
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+# 
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+use strict;
+
+use esmith::event;
+use esmith::ConfigDB;
+
+my $errors = 0;
+
+# Execute this script only in case of upgrade
+if ( ! -f "/var/run/.nethserver-upgrade-configdb" ) {
+   exit 0;
+}
+
+my $confdb = esmith::ConfigDB->open() || die("Could not open ConfigDB");
+
+# Enable acl and user_xattr on / filesystem
+my $fstab = $confdb->get('fstab') or return "";
+
+my $prop = $fstab->prop('/') || 'defaults';
+
+# Skip XFS filesystems and fix existing ones
+my @filesystems=`lsblk -ln -o MOUNTPOINT,FSTYPE`;
+foreach (@filesystems) {
+    chomp;
+    my @tmp = split(/\s+/,$_);
+    if ($tmp[0] eq '/' && ($tmp[1] eq 'xfs' || $tmp[1] eq 'btrfs')) {
+        # Fix existing FS
+        my @options;
+        foreach my $opt (split(',',$prop)) {
+            if ($opt eq 'user_xattr' || $opt eq 'acl') {
+                next;
+            } else {
+                push(@options, $opt);
+            }
+        }
+        $fstab->set_prop('/',join(',',@options));
+
+        exit (! esmith::event::event_signal('fstab-update'));
+    }
+}
+
+$prop .= ",acl" unless ($prop =~ /acl/);
+$prop .= ",user_xattr" unless ($prop =~ /user_xattr/);
+$fstab->set_prop('/',$prop);
+
+if( ! esmith::event::event_signal('fstab-update')) {
+    warn "[ERROR] Errors during fstab-update event";
+    $errors ++;
+}
+
+exit($errors == 0 ? 0 : 1);


### PR DESCRIPTION
Avoid read-only filesystem on upgraded machines where
original machine had nethserver-samba installed,
but the new machine is installed without it

NethServer/dev#5388