### PR TITLE
Typo fix

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-backup-config-list-packages
+++ b/root/etc/e-smith/events/actions/nethserver-backup-config-list-packages
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 tmp=`mktemp`
 rpm -qa --queryformat "%{NAME}\n"| grep ^nethserver- > $tmp


### PR DESCRIPTION
Shebang misspelled.

It's not really making a difference, it's just a cosmetic change.