### PR TITLE
Allow automatic interface remap

### DIFF
--- a/root/etc/e-smith/events/actions/interface-update-cond
+++ b/root/etc/e-smith/events/actions/interface-update-cond
@@ -22,10 +22,11 @@
 
 flag=/var/run/.nethserver-fixnetwork
 
-if [[ ! -f $flag ]]; then
+# remove the event name from the arg list:
+shift
+
+if [[ ! -f $flag || $# -gt 0 ]]; then
     /etc/e-smith/events/actions/initialize-default-databases $*
-    # remove the event name from the arg list:
-    shift
     exec /sbin/e-smith/signal-event interface-update $*
 fi
 

--- a/root/etc/e-smith/events/actions/interface-update-cond
+++ b/root/etc/e-smith/events/actions/interface-update-cond
@@ -26,7 +26,7 @@ flag=/var/run/.nethserver-fixnetwork
 shift
 
 if [[ ! -f $flag || $# -gt 0 ]]; then
-    /etc/e-smith/events/actions/initialize-default-databases $*
-    exec /sbin/e-smith/signal-event interface-update $*
+    /etc/e-smith/events/actions/initialize-default-databases
+    exec /sbin/e-smith/signal-event interface-update "$*"
 fi
 

--- a/root/sbin/e-smith/restore-config
+++ b/root/sbin/e-smith/restore-config
@@ -27,13 +27,17 @@ use Getopt::Long;
 
 my $reinstall = 1;
 my @mask_units;
+my @remap_interfaces;
 
 # The --reinstall option does not take an argument and may be negated
 # by prefixing it with "no" or "no-": --no-reinstall --noreinstall
 GetOptions(
     'reinstall!' => \$reinstall,
     'mask-unit=s' => \@mask_units,
+    'remap-interfaces=s@' => \@remap_interfaces # comma separated list
 );
+
+@remap_interfaces = split(/,/,join(',',@remap_interfaces));
 
 my $status;
 
@@ -99,7 +103,7 @@ if ($reinstall) {
 $ENV{'PTRACK_TASKID'} = $tasks{'post'};
 $tracker->set_task_progress($tasks{'post'}, 0.1, 'Post-restore');
 system('/usr/bin/systemctl', 'mask', '--runtime', @mask_units);
-$status = system("/sbin/e-smith/signal-event post-restore-config");
+$status = system("/sbin/e-smith/signal-event", "post-restore-config", @remap_interfaces);
 system('/usr/bin/systemctl', 'unmask', '--runtime', @mask_units);
 if($status != 0) {
     $tracker->set_task_done($tasks{'post'}, "Event post-restore-config failed", 1);


### PR DESCRIPTION
If restore-config is invoked with 'remap-interfaces',
network interfaces are remapped during post-restore-config event.

Example:
restore-config --remap-interfaces enp0s1,enp0s3

NethServer/dev#5660