### PR TITLE
rsync upgrade: exclude backup history dir

### DIFF
--- a/root/sbin/e-smith/rsync-upgrade
+++ b/root/sbin/e-smith/rsync-upgrade
@@ -115,6 +115,9 @@ if [ $sync_only -eq 1 ]; then
     echo "/root/.ssh" >> $exclude_f
 fi
 
+# Avoid deleting backup history directory
+echo "/var/lib/nethserver/backup/history" >> $exclude_f
+
 # Execute the sync
 rsync -azvr --delete --files-from=$include_f --exclude-from=$exclude_f -e "$ssh_cmd" root@$target:/ /
 


### PR DESCRIPTION
If the directory is deleted by rsync command, the configuration backup
history will not work on the migrated machine.

NethServer/dev#5747