### PR TITLE
 Warm YUM RPMs cache in pre-restore-config event 

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -41,14 +41,7 @@ $event = "nethserver-backup-config-save";
 #--------------------------------------------------
 
 event_actions('pre-restore-config', qw(
-    restore-config-checkupdate 80
-));
-
-#--------------------------------------------------
-# actions for pre-restore-config event
-#--------------------------------------------------
-
-event_actions('pre-restore-config', qw(
+    restore-config-checkupdate 20
     restore-config-download 25
     restore-config-nsdc 30
 ));

--- a/createlinks
+++ b/createlinks
@@ -45,6 +45,15 @@ event_actions('pre-restore-config', qw(
 ));
 
 #--------------------------------------------------
+# actions for pre-restore-config event
+#--------------------------------------------------
+
+event_actions('pre-restore-config', qw(
+    restore-config-download 25
+    restore-config-nsdc 30
+));
+
+#--------------------------------------------------
 # actions for post-restore-config event
 #--------------------------------------------------
 

--- a/root/etc/e-smith/events/actions/restore-config-download
+++ b/root/etc/e-smith/events/actions/restore-config-download
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2019 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+packagelist_path=/var/lib/nethserver/backup/package-list
+backup_path=/var/lib/nethserver/backup/backup-config.tar.xz
+
+packages=($(tar -x -O -f ${backup_path} ${packagelist_path:1} | sed -f /etc/nethserver/ns6upgrade-package-list.sed))
+
+if (( ${#packages[@]} == 0 )); then
+    echo "[WARNING] no packages listed for download"
+    exit 0
+fi
+
+yum -y --downloadonly install "${packages[@]}"

--- a/root/etc/e-smith/events/actions/restore-config-download
+++ b/root/etc/e-smith/events/actions/restore-config-download
@@ -20,6 +20,17 @@
 # along with NethServer.  If not, see COPYING.
 #
 
+while (( $# > 0 )); do
+    if [[ $1 == '--no-reinstall' ]]; then
+        no_reinstall=1
+    fi
+    shift
+done
+
+if [[ -n ${no_reinstall} ]]; then
+    exit 0
+fi
+
 packagelist_path=/var/lib/nethserver/backup/package-list
 backup_path=/var/lib/nethserver/backup/backup-config.tar.xz
 

--- a/root/etc/e-smith/events/actions/restore-config-nsdc
+++ b/root/etc/e-smith/events/actions/restore-config-nsdc
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2019 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+# This is an ad-hoc script to download nethserver-dc required RPMs that would be
+# otherwise ignored by "restore-config-download". Keep it up-to-date with
+# "nethserver-dc-install"!
+
+nsroot=/var/lib/machines/nsdc
+tmprpm=$(mktemp --tmpdir -t ns-samba-XXXXXXXXX.x86_64.rpm)
+
+trap "rm -rf ${tmprpm}" EXIT
+
+if [[ -d ${nsroot}/etc/yum/var ]]; then
+    echo "[WARNING] the nethserver-dc package seems to be already installed" 1>&2
+    exit 0
+fi
+
+nsdc_package=$(find /var/cache/yum -name nethserver-dc*.rpm)
+if [[ -f ${nsdc_package} ]]; then
+    rpm2cpio ${nsdc_package} | cpio -i --to-stdout './usr/lib/nethserver-dc/ns-samba-*.x86_64.rpm' > ${tmprpm}
+    mkdir -p ${nsroot}/etc/yum/vars
+    mkdir -p ${nsroot}/var/log/journal
+    mkdir -p ${nsroot}/etc/systemd/network
+    cp -f /etc/yum/vars/* ${nsroot}/etc/yum/vars
+    rpm --root=${nsroot} --import /etc/pki/rpm-gpg/*
+    yum -y --releasever=/ --installroot=${nsroot} --downloadonly install ${tmprpm} centos-release systemd-networkd bind-utils ntp
+    if [[ $? != 0 ]]; then
+        echo "[ERROR] failed to download nsdc packages" 1>&2
+        rm -rf ${nsroot}
+        exit 1
+    fi
+    rm -f ${nsroot}/etc/krb5.conf
+fi
+

--- a/root/etc/e-smith/events/actions/restore-config-reinstall
+++ b/root/etc/e-smith/events/actions/restore-config-reinstall
@@ -19,21 +19,16 @@
 # along with NethServer.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+packagelist_path=/var/lib/nethserver/backup/package-list
 
-if [ -f /var/lib/nethserver/backup/package-list ]; then
-
-    # Migrate packages from NS 6 to NS 7
-    # See: http://docs.nethserver.org/en/v7/release_notes.html#discontinued-packages
-    sed -i \
-       -e 's/^nethserver-vpn$/nethserver-openvpn\nnethserver-ipsec-tunnels/'  \
-       -e 's/^nethserver-collectd-web$/nethserver-cgp/' \
-       -e 's/^nethserver-fetchmail$/nethserver-getmail/' \
-       -e 's/^nethserver-snort$/nethserver-suricata/' \
-       -e 's/^nethserver-ibays$/nethserver-virtualhosts\nnethserver-samba/' \
-       -e '/^nethserver-c-icap$/d' \
-       -e '/^nethserver-ipsec$/d' \
-    /var/lib/nethserver/backup/package-list
-
-    packages=$(sed ':a;N;$!ba;s/\n/ /g' /var/lib/nethserver/backup/package-list);
-    yum --disableplugin=nethserver_events install -y $packages
+if [ ! -f ${packagelist_path} ]; then
+    echo "[WARNING] restore-config-reinstall: package-list not found, skipped"
+    exit 0
 fi
+
+# Migrate packages from NS 6 to NS 7
+# See: http://docs.nethserver.org/en/v7/release_notes.html#discontinued-packages
+sed -i -f /etc/nethserver/ns6upgrade-package-list.sed ${packagelist_path}
+
+packages=$(sed ':a;N;$!ba;s/\n/ /g' ${packagelist_path});
+yum --disableplugin=nethserver_events install -y $packages

--- a/root/etc/nethserver/ns6upgrade-package-list.sed
+++ b/root/etc/nethserver/ns6upgrade-package-list.sed
@@ -1,0 +1,10 @@
+#
+# sedscript -- replace/delete ns6 package names for the restore-config procedure
+#
+s/^nethserver-vpn$/nethserver-openvpn\nnethserver-ipsec-tunnels/
+s/^nethserver-collectd-web$/nethserver-cgp/
+s/^nethserver-fetchmail$/nethserver-getmail/
+s/^nethserver-snort$/nethserver-suricata/
+s/^nethserver-ibays$/nethserver-virtualhosts\nnethserver-samba/
+/^nethserver-c-icap$/d
+/^nethserver-ipsec$/d

--- a/root/sbin/e-smith/restore-config
+++ b/root/sbin/e-smith/restore-config
@@ -61,7 +61,7 @@ $tracker->set_task_done($tasks{'extract'}, 0);
 
 $ENV{'PTRACK_TASKID'} = $tasks{'pre'};
 $tracker->set_task_progress($tasks{'pre'}, 0.1, 'Pre-restore');
-if ($status = system('/sbin/e-smith/signal-event', 'pre-restore-config'))
+if ($status = system('/sbin/e-smith/signal-event', 'pre-restore-config', $reinstall ? '--reinstall' : '--no-reinstall'))
 {
     $tracker->set_task_done($tasks{'pre'}, "", 1);
     error("Event pre-restore-config: FAIL");


### PR DESCRIPTION
- download backup-config required packages
- download nethserver-dc required packages (if it is listed in backup-config)

The new `/etc/nethserver/ns6upgrade-package-list.sed` holds the packages conversion for the ns6 upgrade logic. It has been moved out of `restore-config-reinstall` to reuse it also in `restore-config-download`.

https://github.com/NethServer/dev/issues/5794