### PR TITLE
Restore: skip network configuration on request

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -55,6 +55,7 @@ $event = "post-restore-config";
 event_actions($event, qw(
     nethserver-backup-config-setupgradeflag 00
     adjust-fixnetwork-flag 01
+    nethserver-backup-config-network-reset 01
     interface-update-cond 70
     system-adjust 70
     nethserver-backup-config-clearupgradeflag-cond 99

--- a/root/etc/e-smith/events/actions/interface-update-cond
+++ b/root/etc/e-smith/events/actions/interface-update-cond
@@ -25,6 +25,11 @@ flag=/var/run/.nethserver-fixnetwork
 # remove the event name from the arg list:
 shift
 
+if [[ $# -gt 0 && $1 == "--skip-network" ]]; then
+    echo "[NOTICE] Skipping interface-update event because of --skip-network option"
+    exit 0
+fi
+
 if [[ ! -f $flag || $# -gt 0 ]]; then
     /etc/e-smith/events/actions/initialize-default-databases
     exec /sbin/e-smith/signal-event interface-update "$@"

--- a/root/etc/e-smith/events/actions/nethserver-backup-config-network-reset
+++ b/root/etc/e-smith/events/actions/nethserver-backup-config-network-reset
@@ -1,0 +1,48 @@
+#!/usr/bin/perl
+
+#
+# Copyright (C) 2020 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+use warnings;
+use strict;
+use esmith::NetworksDB;
+use esmith::ConfigDB;
+
+my $ndb = esmith::NetworksDB->open();
+my $cdb = esmith::ConfigDB->open();
+
+if (grep(/^--skip-network$/, @ARGV)) {
+
+    # Delete all network interfaces
+    foreach my $item ($ndb->get_all()) {
+        if ($item->prop('type') =~ m/^(ethernet|bridge|bond|slave|vlan|alias)$/) {
+            $item->delete();
+        }
+        if ($item->key eq 'ppp0') {
+            $item->set_prop('type', 'xdsl-disabled');
+        }
+    }
+
+    # Preserve upstream DNS, which will be overridden by the below action
+    my $dns = $cdb->get_prop('dns', 'NameServers');
+    system("/etc/e-smith/events/actions/nethserver-base-initialize-db");
+    # Restore previously saved DNS
+    $cdb->set_prop('dns', 'NameServers', $dns);
+}

--- a/root/sbin/e-smith/restore-config
+++ b/root/sbin/e-smith/restore-config
@@ -28,13 +28,15 @@ use Getopt::Long;
 my $reinstall = 1;
 my @mask_units;
 my @remap_interfaces;
+my $skip_network = 0;
 
 # The --reinstall option does not take an argument and may be negated
 # by prefixing it with "no" or "no-": --no-reinstall --noreinstall
 GetOptions(
     'reinstall!' => \$reinstall,
     'mask-unit=s' => \@mask_units,
-    'remap-interfaces=s@' => \@remap_interfaces # comma separated list
+    'remap-interfaces=s@' => \@remap_interfaces, # comma separated list
+    'skip-network' => \$skip_network
 );
 
 @remap_interfaces = split(/,/,join(',',@remap_interfaces));
@@ -61,7 +63,7 @@ $tracker->set_task_done($tasks{'extract'}, 0);
 
 $ENV{'PTRACK_TASKID'} = $tasks{'pre'};
 $tracker->set_task_progress($tasks{'pre'}, 0.1, 'Pre-restore');
-if ($status = system('/sbin/e-smith/signal-event', 'pre-restore-config', $reinstall ? '--reinstall' : '--no-reinstall'))
+if ($status = system('/sbin/e-smith/signal-event', 'pre-restore-config', $reinstall ? '--reinstall' : '--no-reinstall', $skip_network ? '--skip-network' : '--no-skip-network'))
 {
     $tracker->set_task_done($tasks{'pre'}, "", 1);
     error("Event pre-restore-config: FAIL");
@@ -94,7 +96,7 @@ if ($reinstall) {
 $ENV{'PTRACK_TASKID'} = $tasks{'post'};
 $tracker->set_task_progress($tasks{'post'}, 0.1, 'Post-restore');
 system('/usr/bin/systemctl', 'mask', '--runtime', @mask_units);
-$status = system("/sbin/e-smith/signal-event", "post-restore-config", @remap_interfaces);
+$status = system("/sbin/e-smith/signal-event", "post-restore-config", $skip_network ? '--skip-network' : @remap_interfaces);
 system('/usr/bin/systemctl', 'unmask', '--runtime', @mask_units);
 if($status != 0) {
     $tracker->set_task_done($tasks{'post'}, "", 1);

--- a/root/sbin/e-smith/restore-config
+++ b/root/sbin/e-smith/restore-config
@@ -95,9 +95,13 @@ if ($reinstall) {
 
 $ENV{'PTRACK_TASKID'} = $tasks{'post'};
 $tracker->set_task_progress($tasks{'post'}, 0.1, 'Post-restore');
-system('/usr/bin/systemctl', 'mask', '--runtime', @mask_units);
+if (scalar(@mask_units)) {
+    system('/usr/bin/systemctl', 'mask', '--runtime', @mask_units);
+}
 $status = system("/sbin/e-smith/signal-event", "post-restore-config", $skip_network ? '--skip-network' : @remap_interfaces);
-system('/usr/bin/systemctl', 'unmask', '--runtime', @mask_units);
+if (scalar(@mask_units)) {
+    system('/usr/bin/systemctl', 'unmask', '--runtime', @mask_units);
+}
 if($status != 0) {
     $tracker->set_task_done($tasks{'post'}, "", 1);
     error("Event post-restore-config: FAIL");


### PR DESCRIPTION
Add a new `--skip-network` parameter to disable network configuration and remapping at the end of the restore.

In this scenario, the post-restore will reset the network database and reload current network configuration using a network script from `system-init`.
Each package should take care to disable its own configurations not available after the network reset.

NethServer/dev#6099