### PR TITLE
Improve --skip-network implementation

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -41,6 +41,7 @@ $event = "nethserver-backup-config-save";
 #--------------------------------------------------
 
 event_actions('pre-restore-config', qw(
+    nethserver-backup-config-network-preserve 10
     restore-config-checkupdate 20
     restore-config-download 25
     restore-config-nsdc 30

--- a/root/etc/e-smith/events/actions/nethserver-backup-config-network-preserve
+++ b/root/etc/e-smith/events/actions/nethserver-backup-config-network-preserve
@@ -1,0 +1,33 @@
+#!/usr/bin/bash
+
+#
+# Copyright (C) 2020 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+#
+# Copy networks db which will be restored later
+#
+
+# Execute only if skip-network option is enabled
+echo $@ | grep -- '--skip-network'
+if [ $? -gt 0 ]; then
+    exit 0
+fi
+
+/bin/cp -p /var/lib/nethserver/db/networks /var/lib/nethserver/db/networks.preserve

--- a/root/etc/e-smith/events/actions/nethserver-backup-config-network-reset
+++ b/root/etc/e-smith/events/actions/nethserver-backup-config-network-reset
@@ -26,23 +26,36 @@ use esmith::NetworksDB;
 use esmith::ConfigDB;
 
 my $ndb = esmith::NetworksDB->open();
-my $cdb = esmith::ConfigDB->open();
+
+my $net_backup = "/var/lib/nethserver/db/networks.preserve";
 
 if (grep(/^--skip-network$/, @ARGV)) {
 
-    # Delete all network interfaces
-    foreach my $item ($ndb->get_all()) {
-        if ($item->prop('type') =~ m/^(ethernet|bridge|bond|slave|vlan|alias)$/) {
-            $item->delete();
-        }
-        if ($item->key eq 'ppp0') {
-            $item->set_prop('type', 'xdsl-disabled');
-        }
-    }
+    if ( -f $net_backup ) {
+        # This is the database to preserve
+        my $old_ndb = esmith::NetworksDB->open($net_backup);
 
-    # Preserve upstream DNS, which will be overridden by the below action
-    my $dns = $cdb->get_prop('dns', 'NameServers');
-    system("/etc/e-smith/events/actions/nethserver-base-initialize-db");
-    # Restore previously saved DNS
-    $cdb->set_prop('dns', 'NameServers', $dns);
+        # Migrate restored records to the backup copy
+        foreach my $item ($ndb->get_all()) {
+            my $key = $item->key;
+            my $type = $item->prop('type');
+
+            # Skip all network interfaces
+            next if ($type =~ m/^(ethernet|bridge|bond|slave|vlan|alias|xdsl|xdsl-disabled)$/);
+
+            # Create the item if not exists, otherwise just merge the props
+            my $new_item = $old_ndb->get($key) || $old_ndb->new_record($key, { type => $type});
+            $new_item->merge_props($item->props);
+        }
+
+        # Flush changes to disk
+        $old_ndb->reload();
+
+        # Remove network db from backup and restore the previous one
+        unlink("/var/lib/nethserver/db/networks");
+        rename($net_backup, "/var/lib/nethserver/db/networks");
+
+    } else {
+        print "[WARNING] Network could not be preserved: '$net_backup' not found\n";
+    }
 }

--- a/root/etc/e-smith/events/actions/nethserver-backup-config-network-reset
+++ b/root/etc/e-smith/events/actions/nethserver-backup-config-network-reset
@@ -51,8 +51,7 @@ if (grep(/^--skip-network$/, @ARGV)) {
         # Flush changes to disk
         $old_ndb->reload();
 
-        # Remove network db from backup and restore the previous one
-        unlink("/var/lib/nethserver/db/networks");
+        # Restore the previous networks db
         rename($net_backup, "/var/lib/nethserver/db/networks");
 
     } else {


### PR DESCRIPTION
Do not destroy existing network interface configuration, but merge
trusted networks, zones etc from the backup into the actual network
database.

Such implementation preserves all logical network interfaces present
on the target machine.

NethServer/dev#6099