### PR TITLE
spec: create srvmgr user

### DIFF
--- a/nethserver-backup-config.spec
+++ b/nethserver-backup-config.spec
@@ -38,6 +38,14 @@ rm -rf %{buildroot}
 %{genfilelist} %{buildroot} > %{name}-%{version}-%{release}-filelist
 mkdir -p %{buildroot}/%{_nsstatedir}/backup/history
 
+%pre
+# ensure srvmgr user exists:
+# configuration backups must be owned by srvmgr user otherwise
+# httpd-admin will not be able to deleted them
+if ! id srvmgr >/dev/null 2>&1 ; then
+   useradd -r -U -G adm srvmgr
+fi
+
 %files -f %{name}-%{version}-%{release}-filelist 
 %defattr(-,root,root)
 %config /etc/backup-config.d/custom.include


### PR DESCRIPTION
Since nethserver-httpd-admin is not installed by default,
backup history files are owned by root because srvmgr user does not
exists.

If nethserver-httpd-admin has been installed at later time,
NethGUI will not be able to handle such files.

This fix prevents such scenario by making sure srvmgr user is always
present.

NethServer/dev#6375